### PR TITLE
Get ClrVersion from 64-Bit process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+# Visual Studio 2015/2017 cache/options directory
+.vs/
 
 # Roslyn cache directories
 *.ide/

--- a/DotMemMemoryProfiler/DotMemMemoryProfiler/AnalyzingWindow.xaml.cs
+++ b/DotMemMemoryProfiler/DotMemMemoryProfiler/AnalyzingWindow.xaml.cs
@@ -20,7 +20,7 @@ using Newtonsoft.Json;
 namespace DotMemMemoryProfiler
 {
     /// <summary>
-    /// Interaction logic for AnalyzingWindow32.xaml
+    /// Interaction logic for AnalyzingWindow.xaml
     /// </summary>
     public partial class AnalyzingWindow : Window
     {
@@ -28,58 +28,28 @@ namespace DotMemMemoryProfiler
         public string connection = @"Data Source=" + path + @"\ProfilerData.sqlite;Version=3; FailIfMissing=True; Foreign Keys=True;";
         private string currentMethod;
         public string processName;
-        int processId;
+        private readonly int processId;
         int clickcounter = 0;
         private string totalPath;
-        string processEnvironment;
+        private readonly string processEnvironment;
         private int snapshotCounter = 0;
         public string profilerDataConnection;
         //Dictionary<int, Dictionary<string, ObjectDetails>> snapshotDataHolder = new Dictionary<int, Dictionary<string, ObjectDetails>>();
         Dictionary<int, ObservableCollection<AppDomainDetails>> appDomaianDataHolder = new Dictionary<int, ObservableCollection<AppDomainDetails>>();
         Dictionary<int, ObservableCollection<HeapHelper.HeapData>> heapDataHolder = new Dictionary<int, ObservableCollection<HeapHelper.HeapData>>();
         AssemblyExaminer assemblyDataHolder = new AssemblyExaminer();
-        /// <summary>
-        /// Constructor that takes 2 arguments (is used for 32 bit processes).
-        /// </summary>
-        /// <param name="message"></param>
-        /// <param name="bit"></param>
         Stopwatch stopwatch;
-        public AnalyzingWindow(string message, string bit, int processId)
-        {
-            stopwatch = Stopwatch.StartNew();
-            InitializeComponent();
-            processName = message;
-            this.processId = processId;
-            Helper x = new Helper(processName, this.processId);
-            x._timer.Start();
-            this.DataContext = x;
-            clickcounter = 1;
-            totalPath = Process.GetProcessesByName(processName)[0].MainModule.FileName;
-            processEnvironment = bit;
-            Closing += AnalyzingWindow_Closing;
-            try
-            {
-                Directory.CreateDirectory(path);
-                File.Create(path + @"\ProfilerData.sqlite");
-            }
-            catch
-            {
-                MessageBox.Show("Database is being accessed by some other program or may be other instance of same program please stop the process and cancel the Messgae box to get reliable data ");
-            }
-
-
-        }
         /// <summary>
-        /// Constructor that takes 3 arguments (is used for 64 bit processes).
+        /// 
         /// </summary>
-        /// <param name="message"></param>
         /// <param name="exePath"></param> 
         /// <param name="bit"></param> 
-        public AnalyzingWindow(string message, string exePath, string bit, int processId)
+        /// <param name="processId"></param> 
+        public AnalyzingWindow(string exePath, string bit, int processId)
         {
             stopwatch = Stopwatch.StartNew();
             InitializeComponent();
-            processName = message;
+            processName = Path.GetFileNameWithoutExtension(exePath);
             this.processId = processId;
             Helper x = new Helper(processName, this.processId);
             x._timer.Start();
@@ -174,7 +144,7 @@ namespace DotMemMemoryProfiler
             {
                 try
                 {
-                    tempPath = Process.GetProcessesByName(processName)[0].MainModule.FileName;
+                    tempPath = Process.GetProcessById(processId).MainModule.FileName;
                 }
                 catch
                 {
@@ -534,8 +504,7 @@ namespace DotMemMemoryProfiler
                     string loc;
                     try
                     {
-                        Process proc = Process.GetProcessesByName(processName)[0];
-                        loc = proc.MainModule.FileName;
+                        loc = Process.GetProcessById(processId).MainModule.FileName;
                     }
                     catch
                     {
@@ -619,11 +588,11 @@ namespace DotMemMemoryProfiler
                     Loadlabel.Visibility = Visibility.Visible;
                     RuntimeHelper helperData = new RuntimeHelper();
                     Loadlabel.Content = "Getting Into Heap \n       Please wait";
-                    CLRStack stackDetails = new CLRStack(processName, processId);
+                    CLRStack stackDetails = new CLRStack(processId);
                     Task<ObservableCollection<AppDomainDetails>> temp = new Task<ObservableCollection<AppDomainDetails>>(stackDetails.GetData);
                     temp.Start();
                     appDomaianDataHolder[snapshotCounter] = await temp;
-                    CLRHeap heapDetails = new CLRHeap(processName, processId);
+                    CLRHeap heapDetails = new CLRHeap(processId);
                     Task<ObservableCollection<HeapHelper.HeapData>> heapDataGetter = new Task<ObservableCollection<HeapHelper.HeapData>>(heapDetails.ObservableCollection);
                     heapDataGetter.Start();
                     heapDataHolder[snapshotCounter] = await heapDataGetter;

--- a/DotMemMemoryProfiler/DotMemMemoryProfiler/CLRHeap.cs
+++ b/DotMemMemoryProfiler/DotMemMemoryProfiler/CLRHeap.cs
@@ -28,10 +28,9 @@ namespace CLRMD
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
         int processId;
-        public CLRHeap(string processName,int processId)
+        public CLRHeap(int processId)
         {
             this.processId = processId;
-            Process process = Process.GetProcessesByName(processName)[0];           
             Objects = new Dictionary<ClrType, ObservableCollection<HeapHelper.Object>>();
         }
 

--- a/DotMemMemoryProfiler/DotMemMemoryProfiler/CLRStack.cs
+++ b/DotMemMemoryProfiler/DotMemMemoryProfiler/CLRStack.cs
@@ -28,10 +28,9 @@ namespace DotMemMemoryProfiler
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
         private int processId;
-        public CLRStack(string processName,int processId)
+        public CLRStack(int processId)
         {
-            Process process = Process.GetProcessesByName(processName)[0];
-            this.processId = processId;        
+            this.processId = processId;
         }
         public  ObservableCollection<AppDomainDetails> GetData()
         {           

--- a/DotMemMemoryProfiler/DotMemMemoryProfiler/MemoryReciter.csproj
+++ b/DotMemMemoryProfiler/DotMemMemoryProfiler/MemoryReciter.csproj
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,26 +36,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/DotMemMemoryProfiler/MemoryReciter.sln
+++ b/DotMemMemoryProfiler/MemoryReciter.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1082
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemoryReciter", "DotMemMemoryProfiler\MemoryReciter.csproj", "{0FB9E468-F305-4D58-913E-85C8F8F73D92}"
 EndProject
@@ -12,31 +12,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Debug|x64.ActiveCfg = Debug|x64
-		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Debug|x64.Build.0 = Debug|x64
 		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Release|x64.ActiveCfg = Release|x64
-		{0FB9E468-F305-4D58-913E-85C8F8F73D92}.Release|x64.Build.0 = Release|x64
 		{303914A4-DE6A-4970-8CEA-10FBD3A2AAF7}.Debug|Any CPU.ActiveCfg = Debug
-		{303914A4-DE6A-4970-8CEA-10FBD3A2AAF7}.Debug|x64.ActiveCfg = Debug
 		{303914A4-DE6A-4970-8CEA-10FBD3A2AAF7}.Release|Any CPU.ActiveCfg = Release
-		{303914A4-DE6A-4970-8CEA-10FBD3A2AAF7}.Release|x64.ActiveCfg = Release
 		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Debug|x64.Build.0 = Debug|Any CPU
 		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Release|x64.ActiveCfg = Release|Any CPU
-		{84D4DA84-31BD-4622-B2C2-4E76197FFA0A}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I create this because my 64-Bit Process was not able to get ClrVersion. Running Memory-Reciter as 64-Bit application (if possible for sure) then it just works.

Additionally:
- removed few code duplications
- use `GetProcessById` instead of byName